### PR TITLE
nest apiKeys under apiGateway

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -34,8 +34,9 @@ provider:
   deploymentBucket:
     name: ${self:custom.deploy.bucket_name}
     blockPublicAccess: true
-  apiKeys:
-    - ${self:custom.stage}-i90-default
+  apiGateway:
+    apiKeys:
+      - ${self:custom.stage}-i90-default
   iamRoleStatements:
     - Effect: Allow
       Action:


### PR DESCRIPTION
When using serverless v3, apiKeys needs to be nested under apiGateway.